### PR TITLE
Adds support for string query-string parameter in the request function

### DIFF
--- a/src/clj/qbits/jet/client/http.clj
+++ b/src/clj/qbits/jet/client/http.clj
@@ -361,10 +361,8 @@
     (when auth
       (.apply auth request))
 
-    (cond
-      (string? query-string)
+    (if (string? query-string)
       (set-query-string! request query-string)
-      :else
       (doseq [[k v] query-string]
         (if (coll? v)
           (doseq [v' v]

--- a/src/clj/qbits/jet/client/http.clj
+++ b/src/clj/qbits/jet/client/http.clj
@@ -10,7 +10,9 @@
    [cheshire.core :as json]
    [clojure.xml :as xml])
   (:import
-    (org.eclipse.jetty.client HttpClient)
+    (org.eclipse.jetty.client
+      HttpClient
+      HttpRequest)
     (org.eclipse.jetty.util Fields)
     (org.eclipse.jetty.client.util
       StringContentProvider
@@ -272,6 +274,13 @@
   [^HttpClient cl]
   (.stop cl))
 
+(defn- set-query-string!
+  "Configures the query string in the request object directly."
+  [^HttpRequest request query-string]
+  (let [query-field (.getDeclaredField HttpRequest "query")]
+    (.setAccessible query-field true)
+    (.set query-field request query-string)))
+
 (defn request
   [^HttpClient client
    {:keys [url method query-string form-params headers body
@@ -352,11 +361,15 @@
     (when auth
       (.apply auth request))
 
-    (doseq [[k v] query-string]
-      (if (coll? v)
-        (doseq [v' v]
-          (.param request (name k) (str v')))
-        (.param request (name k) (str v))))
+    (cond
+      (string? query-string)
+      (set-query-string! request query-string)
+      :else
+      (doseq [[k v] query-string]
+        (if (coll? v)
+          (doseq [v' v]
+            (.param request (name k) (str v')))
+          (.param request (name k) (str v)))))
 
     (when cookies
       (doseq [[name value] cookies]

--- a/src/clj/qbits/jet/client/http.clj
+++ b/src/clj/qbits/jet/client/http.clj
@@ -277,9 +277,9 @@
 (defn- set-query-string!
   "Configures the query string in the request object directly."
   [^HttpRequest request query-string]
-  (let [query-field (.getDeclaredField HttpRequest "query")]
-    (.setAccessible query-field true)
-    (.set query-field request query-string)))
+  (doto (.getDeclaredField HttpRequest "query")
+    (.setAccessible true)
+    (.set request query-string)))
 
 (defn request
   [^HttpClient client


### PR DESCRIPTION
## Changes proposed in this PR

- adds support for string query-string parameter in the request function

## Why are we making these changes?

We would like the library to be resilient to the presence of special characters in the query string.

### Previous behavior

This was the error that was thrown when we tried to pass in the query string in `uri`:

```
2018-05-01 12:03:04,845 ERROR waiter.process-request [async-dispatch-50] - [CID=51f97bec24f6-36056137f5bdefc9] error during process
java.lang.IllegalArgumentException: Illegal character in query at index 41: http://127.0.0.5:10000/request-info?bad=a|b
	at java.net.URI.create(URI.java:852)
	at org.eclipse.jetty.client.HttpClient.newRequest(HttpClient.java:418)
	at qbits.jet.client.http$request.invokeStatic(http.clj:302)
	at qbits.jet.client.http$request.invoke(http.clj:275)
	at qbits.jet.client.http$get.invokeStatic(http.clj:398)
	at qbits.jet.client.http$get.invoke(http.clj:396)
	at waiter.process_request$make_http_request.invokeStatic(process_request.clj:227)
	at waiter.process_request$make_http_request.invoke(process_request.clj:219)
...
```
