### PR TITLE
Updates jetty version to 9.4.9.v20180320

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def jetty-version "9.4.5.v20170502")
+(def jetty-version "9.4.9.v20180320")
 (defproject cc.qbits/jet "0.7.10"
   :description "Jetty9 ring server adapter with WebSocket support"
   :url "https://github.com/mpenet/jet"


### PR DESCRIPTION
## Changes proposed in this PR

- updates jetty version to 9.4.9.v20180320

## Why are we making these changes?

We would like to be running the latest version of Jetty. 

### Note

Jetty 9.4.9 has the bug fix reported by @pschorf https://github.com/eclipse/jetty.project/issues/1116

Waiter Build: https://github.com/twosigma/waiter/pull/306