### PR TITLE
Makes the transport on the http client configurable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
                  [org.eclipse.jetty/jetty-alpn-server ~jetty-version]
                  [org.eclipse.jetty.alpn/alpn-api "1.1.2.v20150522"]
                  [org.eclipse.jetty.http2/http2-common ~jetty-version]
-                 ;; [org.eclipse.jetty.http2/http2-http-client-transport ~jetty-version]
+                 [org.eclipse.jetty.http2/http2-http-client-transport ~jetty-version]
                  ;; [org.eclipse.jetty.http2/http2-client ~jetty-version]
                  ;; [org.eclipse.jetty/jetty-alpn-client ~jetty-version]
                  [cheshire "5.5.0"]]

--- a/src/clj/qbits/jet/client/http.clj
+++ b/src/clj/qbits/jet/client/http.clj
@@ -35,6 +35,8 @@
       Request
       Response$AsyncContentListener
       Result)
+    (org.eclipse.jetty.client.http
+      HttpClientTransportOverHTTP)
     (java.util.concurrent TimeUnit)
     java.net.HttpCookie
     (java.nio ByteBuffer)
@@ -210,17 +212,19 @@
             dispatch-io?
             tcp-no-delay?
             strict-event-ordering?
-            ssl-context-factory]
+            ssl-context-factory
+            transport]
      :or {remove-idle-destinations? true
           dispatch-io? true
           follow-redirects? true
           tcp-no-delay? true
           strict-event-ordering? false
           ssl-context-factory @default-insecure-ssl-context-factory
+          transport (HttpClientTransportOverHTTP.)
           request-buffer-size default-buffer-size
           response-buffer-size default-buffer-size}
      :as r}]
-   (let [client (HttpClient. ssl-context-factory)]
+   (let [client (HttpClient. transport ssl-context-factory)]
 
      (when address-resolution-timeout
        (.setAddressResolutionTimeout client (long address-resolution-timeout)))


### PR DESCRIPTION
By default, HttpClientTransportOverHTTP, is chosen as the mechanism in which HTTP exchange is carried over the network for a request. We wish to have it configurable so we can use HTTP/2 protocol as the transport mechanism.