### PR TITLE
Refactors Response object and version option in request

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,9 @@
                  [cheshire "5.5.0"]]
 
   :plugins [[info.sunng/lein-bootclasspath-deps "0.3.0"]
-            [lein-voom "0.1.0-20171225_233657-g7962d1d"]]
+            [lein-voom "0.1.0-20180617_140646-g0ba7ec8" :exclusions [org.clojure/core.logic]]
+            ;; 0.8.10 of core.logic is not clojure 1.10 compatible
+            [org.clojure/core.logic "0.8.11"]]
   :boot-dependencies [[org.mortbay.jetty.alpn/alpn-boot "8.1.3.v20150130"
                        :prepend true]]
 

--- a/project.clj
+++ b/project.clj
@@ -22,10 +22,7 @@
                  ;; [org.eclipse.jetty/jetty-alpn-client ~jetty-version]
                  [cheshire "5.5.0"]]
 
-  :plugins [[info.sunng/lein-bootclasspath-deps "0.3.0"]
-            [lein-voom "0.1.0-20180617_140646-g0ba7ec8" :exclusions [org.clojure/core.logic]]
-            ;; 0.8.10 of core.logic is not clojure 1.10 compatible
-            [org.clojure/core.logic "0.8.11"]]
+  :plugins [[info.sunng/lein-bootclasspath-deps "0.3.0"]]
   :boot-dependencies [[org.mortbay.jetty.alpn/alpn-boot "8.1.3.v20150130"
                        :prepend true]]
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def jetty-version "9.4.9.v20180320")
-(defproject cc.qbits/jet "0.7.10"
+(defproject twosigma/jet "0.7.10"
   :description "Jetty9 ring server adapter with WebSocket support"
   :url "https://github.com/mpenet/jet"
   :license {:name "Eclipse Public License"

--- a/src/clj/qbits/jet/client/http.clj
+++ b/src/clj/qbits/jet/client/http.clj
@@ -25,7 +25,8 @@
       MultiPartContentProvider)
     (org.eclipse.jetty.http
       HttpFields
-      HttpField)
+      HttpField
+      HttpVersion)
     (org.eclipse.jetty.client.api
       Authentication$Result
       ContentProvider
@@ -327,8 +328,9 @@
                               (decode-chunk-xform as)))
         ^Request request (.newRequest client ^String url)]
 
-    (when version
-      (.version request version))
+    (some->> version
+      HttpVersion/fromString
+      (.version request))
 
     (.followRedirects request follow-redirects?)
 

--- a/src/clj/qbits/jet/client/http.clj
+++ b/src/clj/qbits/jet/client/http.clj
@@ -34,6 +34,7 @@
       Response$CompleteListener
       Response$HeadersListener
       Request
+      Response
       Response$AsyncContentListener
       Result)
     (org.eclipse.jetty.client.http
@@ -101,10 +102,8 @@
       ([result chunk]
        (reduction-function result (decode-body chunk as))))))
 
-(defrecord Response [request status headers body error-chan])
-
 (defn- make-response
-   [request ^org.eclipse.jetty.client.api.Response response body-ch error-chan]
+   [request ^Response response body-ch error-chan]
    (let [headers (reduce (fn [m ^HttpField h]
                              (let [k (string/lower-case (.getName h))
                                    v (.getValue h)]
@@ -116,7 +115,11 @@
                          {}
                          ^HttpFields (.getHeaders response))
          status (.getStatus response)]
-     (Response. request status headers body-ch error-chan)))
+     {:body body-ch
+      :error-chan error-chan
+      :headers headers
+      :request request
+      :status status}))
 
 (defprotocol PRequest
   (encode-chunk [x])


### PR DESCRIPTION
Changes:

- removes voom from plugins
- uses string instead expecting client of send HttpVersion object
- avoids need to load (and possibility of NoClassDefError) for response…  …
- changes project name to twosigma/jet