### PR TITLE
adds ALPN support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.mortbay.jetty.alpn/alpn-boot "8.1.3.v20150130"
+                 [org.mortbay.jetty.alpn/alpn-boot "8.1.13.v20181017"
                   :prepend true]
                  [org.clojure/core.async "0.2.374"]
                  [org.eclipse.jetty/jetty-server ~jetty-version]
@@ -14,16 +14,16 @@
                  [org.eclipse.jetty.websocket/websocket-servlet ~jetty-version]
                  [org.eclipse.jetty.websocket/websocket-client ~jetty-version]
                  [org.eclipse.jetty/jetty-client ~jetty-version]
-                 [org.eclipse.jetty/jetty-alpn-server ~jetty-version]
+                 [org.eclipse.jetty/jetty-alpn-openjdk8-client ~jetty-version]
+                 [org.eclipse.jetty/jetty-alpn-openjdk8-server ~jetty-version]
                  [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]
                  [org.eclipse.jetty.http2/http2-common ~jetty-version]
                  [org.eclipse.jetty.http2/http2-http-client-transport ~jetty-version]
                  [org.eclipse.jetty.http2/http2-client ~jetty-version]
-                 ;; [org.eclipse.jetty/jetty-alpn-client ~jetty-version]
                  [cheshire "5.5.0"]]
 
   :plugins [[info.sunng/lein-bootclasspath-deps "0.3.0"]]
-  :boot-dependencies [[org.mortbay.jetty.alpn/alpn-boot "8.1.3.v20150130"
+  :boot-dependencies [[org.mortbay.jetty.alpn/alpn-boot "8.1.13.v20181017"
                        :prepend true]]
 
   :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"


### PR DESCRIPTION
Based on the [application here](https://www.programcreek.com/java-api-examples/?code=AndreasKl/embedded-jetty-http2/embedded-jetty-http2-master/src/main/java/net/andreaskluth/Application.java).

```
$ curl -v -k --http2 "https://localhost:9099/status?include=request-info"
...
* Connected to localhost (::1) port 9099 (#0)                                                                                                                                                                                                 
* ALPN, offering h2                                                                                                                                                                                                                           
* ALPN, offering http/1.1        
...
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use h2
...
< HTTP/2 200     
< content-type: application/json
...
```

```
$ curl -v -k --http1.1 "https://localhost:9099/status?include=request-info" | jq .                                                                                                                                                  
...
* ALPN, offering http/1.1
...
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
...
< HTTP/1.1 200 OK
< content-type: application/json
...
```
