### PR TITLE
Support for avoiding empty trailers in HTTP/2 requests

### DIFF
--- a/src/clj/qbits/jet/util.clj
+++ b/src/clj/qbits/jet/util.clj
@@ -37,13 +37,15 @@
   [trailers-fn]
   (when trailers-fn
     (reify Supplier
-      (get [_] (map->http-fields (trailers-fn))))))
+      (get [_]
+        (when-let [trailers (trailers-fn)]
+          (map->http-fields trailers))))))
 
 (defn trailers-ch->supplier
   [trailers-ch]
   (when trailers-ch
     (reify Supplier
       (get [_]
-        (let [trailers (or (async/<!! trailers-ch) {})]
+        (when-let [trailers (async/<!! trailers-ch)]
           (map->http-fields trailers))))))
 

--- a/src/clj/qbits/jet/util.clj
+++ b/src/clj/qbits/jet/util.clj
@@ -33,6 +33,12 @@
   (or (= (.asString HttpVersion/HTTP_2) request-protocol)
       (and (nil? content-length) (= transfer-encoding "chunked"))))
 
+(defn trailers->supplier
+  [trailers]
+  (when trailers
+    (reify Supplier
+      (get [_] (map->http-fields trailers)))))
+
 (defn trailers-fn->supplier
   [trailers-fn]
   (when trailers-fn


### PR DESCRIPTION
We would like avoid sending an empty trailers packet when the request has no trailers to send (signalled by returning `nil` in the `trailers-fn`.