### PR TITLE
adds timeout in ms for blocking I/O operations

### DIFF
--- a/src/clj/qbits/jet/server.clj
+++ b/src/clj/qbits/jet/server.clj
@@ -101,10 +101,11 @@ Derived from ring.adapter.jetty"
 
 (defn- http-config
   [{:as options
-    :keys [ssl-port secure-scheme output-buffer-size request-header-size
+    :keys [blocking-timeout ssl-port secure-scheme output-buffer-size request-header-size
            response-header-size send-server-version? send-date-header?
            header-cache-size]
-    :or {ssl-port 443
+    :or {blocking-timeout 3600
+         ssl-port 443
          secure-scheme "https"
          output-buffer-size 32768
          request-header-size 8192
@@ -114,6 +115,7 @@ Derived from ring.adapter.jetty"
          header-cache-size 512}}]
   "Creates jetty http configurator"
   (doto (HttpConfiguration.)
+    (.setBlockingTimeout blocking-timeout)
     (.setSecureScheme secure-scheme)
     (.setSecurePort ssl-port)
     (.setOutputBufferSize output-buffer-size)


### PR DESCRIPTION
Add timeout in ms for blocking I/O operations. This is important as threads can get indeifinitely blocked on read() operations from the input stream:

```
"pool-1-thread-131" #293 prio=5 os_prio=0 tid=0x00007f60e80d8800 nid=0x33d1 in Object.wait() [0x00007f609b3e5000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:502)
	at org.eclipse.jetty.server.HttpInput.blockForContent(HttpInput.java:575)
	at org.eclipse.jetty.server.HttpInput$1.blockForContent(HttpInput.java:1100)
	at org.eclipse.jetty.server.HttpInput.read(HttpInput.java:315)
	- locked <0x00000000949df2c8> (a java.util.ArrayDeque)
	at java.io.InputStream.read(InputStream.java:101)
	at waiter.process_request$eval31985$stream_http_request__31986.invoke(process_request.clj:280)
	at waiter.process_request$eval31985$stream_http_request__31986$invoke_stream_http_request__31987.invoke(process_request.clj:263)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

The issue is in the `if`-branch taken:
https://github.com/eclipse/jetty.project/blob/9706d70484863a014d3604e5e7cb4af40aa4cb1e/jetty-server/src/main/java/org/eclipse/jetty/server/HttpInput.java#L567