### PR TITLE
propagates errors during successful aborts

### DIFF
--- a/src/clj/qbits/jet/client/http.clj
+++ b/src/clj/qbits/jet/client/http.clj
@@ -407,7 +407,10 @@
                                  (async/close! body-ch)
                                  (async/close! trailers-ch)
                                  (async/close! ch)
-                                 (async/close! error-ch))]
+                                 (async/close! error-ch))
+        report-error! (fn report-error! [throwable]
+                        (async/>!! ch {:error throwable})
+                        (async/>!! error-ch {:error throwable}))]
 
     (some->> version
       HttpVersion/fromString
@@ -416,7 +419,8 @@
     (when abort-ch
       (async/go
         (when-let [cause (async/<! abort-ch)]
-          (.abort request cause))))
+          (when (.abort request cause)
+            (report-error! cause)))))
 
     (.followRedirects request follow-redirects?)
 
@@ -517,14 +521,13 @@
     (.onRequestFailure request
                        (reify Request$FailureListener
                          (onFailure [_ _ throwable]
-                           (async/put! ch {:error throwable}))))
+                           (report-error! throwable))))
 
     (.send request
            (reify Response$CompleteListener
              (onComplete [_ result]
                (when (not (.isSucceeded result))
-                   (async/put! ch {:error (.getFailure result)})
-                   (async/put! error-ch {:error (.getFailure result)}))
+                 (report-error! (.getFailure result)))
                (when-let [response (.getResponse result)]
                  (when (instance? HttpResponse response)
                    (when-let [trailers (.getTrailers ^HttpResponse response)]


### PR DESCRIPTION
Changes:
- reports errors on both the potential error channels
- reports errors when abort is successful
- adds a callback support for abort requests

Why?
Makes the error reason consistently available on both as `error` and (when the response has been published) on the `error-chan`. Also, notifies the requester if the abort request is processed.