### PR TITLE
Avoids closing actively streaming body channel after trailers have been received

### DIFF
--- a/src/clj/qbits/jet/client/http.clj
+++ b/src/clj/qbits/jet/client/http.clj
@@ -356,18 +356,21 @@
   "Asynchronously loops and looks for presence of trailers in the response.
    When available, they are propagated to the trailers channel and other request channels closed.
    Please see https://github.com/eclipse/jetty.project/issues/3842 for details on why we need this."
-  [response-trailers-ch response-body-ch close-request-channels! response]
+  [response-trailers-ch response-body-ch content-provider-promise response]
   (async/go
-    (loop []
-      ;; iterate every second and check if trailers are available
-      (async/<! (async/timeout 1000))
-      (let [trailers (.getTrailers ^HttpResponse response)]
-        (if trailers
-          (do
-            (async/>! response-trailers-ch (util/http-fields->map trailers))
-            (close-request-channels!))
-          (when-not (protocols/closed? response-body-ch)
-            (recur)))))))
+    ;; empirically determine the timeout
+    (let [trailer-interval-ms 2000]
+      (loop []
+        ;; iterate and check if trailers are available
+        (async/<! (async/timeout trailer-interval-ms))
+        (let [trailers (.getTrailers ^HttpResponse response)]
+          (if trailers
+            (do
+              (async/>! response-trailers-ch (util/http-fields->map trailers))
+              ;; close the input stream as server has already responded with a trailer
+              (some-> content-provider-promise (deref 0 nil) (.close)))
+            (when-not (protocols/closed? response-body-ch)
+              (recur))))))))
 
 (defn request
   [^HttpClient client
@@ -410,7 +413,11 @@
                                   (async/close! ch))
         report-error! (fn report-error! [throwable]
                         (async/>!! ch {:error throwable})
-                        (async/>!! error-ch {:error throwable}))]
+                        (async/>!! error-ch {:error throwable}))
+        content-provider-promise (promise)
+        assign-content-provider! (fn assign-content-provider! [content-provider]
+                                   (deliver content-provider-promise content-provider)
+                                   content-provider)]
 
     (some->> version
       HttpVersion/fromString
@@ -465,6 +472,7 @@
       ;; HTTP/2 requests with a body need the trailer to set be set as late as possible
       ;; This allows us to avoid sending an empty terminating trailer frame if there are no trailers to send.
       (->> (encode-body body)
+           (assign-content-provider!)
            (untyped-content-provider
              (fn on-request-body-content-read []
                (when trailers-supported?
@@ -476,6 +484,7 @@
       (do
         (when body
           (->> (encode-body body)
+               (assign-content-provider!)
                (untyped-content-provider nil)
                (.content request)))
         (when trailers-supported?
@@ -510,6 +519,7 @@
                                (onContent [_ _ byte-buffer callback]
                                  (if (protocols/closed? body-ch)
                                    (let [ex (IOException. "Body channel closed unexpectedly")]
+                                     (report-error! ex)
                                      (.failed callback ex)
                                      (.abort request ex))
                                    (async/put! body-ch (byte-buffer->bytes byte-buffer)
@@ -520,7 +530,7 @@
                           (onHeaders [_ response]
                             (async/put! ch (make-response request response abort-ch body-ch error-ch trailers-ch))
                             (when (util/http2-request? version)
-                              (track-response-trailers trailers-ch body-ch close-request-channels! response)))))
+                              (track-response-trailers trailers-ch body-ch content-provider-promise response)))))
 
     (.onRequestFailure request
                        (reify Request$FailureListener


### PR DESCRIPTION
Attempts to avoid eagerly closing the body channel while streaming response bytes. The trailer tracker loops every second and checks for inactivity on streaming response bytes before triggering channel close.