### PR TITLE
removes workarounds for empty trailers

### DIFF
--- a/src/clj/qbits/jet/servlet.clj
+++ b/src/clj/qbits/jet/servlet.clj
@@ -286,9 +286,7 @@
           ^Request servlet-request (:servlet-request request-map)
           servlet-response  (.getServletResponse servlet-request)]
       (when (and trailers (instance? Response servlet-response))
-        (let [request-protocol (some-> servlet-request .getProtocol)
-              http2? (util/http2-request? request-protocol)]
-          (.setTrailers ^Response servlet-response (util/trailers-ch->supplier trailers http2?))))
+        (.setTrailers ^Response servlet-response (util/trailers-ch->supplier trailers)))
       (set-status+headers! servlet-response request-map status headers)
       (set-body! servlet-response request-map body)))
 


### PR DESCRIPTION
- removes workaround for sending empty trailers from the client request
- removes workaround for sending empty trailers in the server response
- removes the need for wrapping `AbstractTypedContentProvider` for no default `Content-Type` header