### PR TITLE
Use SslContextFactory Client/Server subclasses

### DIFF
--- a/src/clj/qbits/jet/client/ssl.clj
+++ b/src/clj/qbits/jet/client/ssl.clj
@@ -1,6 +1,8 @@
 (ns qbits.jet.client.ssl
-  (:import (org.eclipse.jetty.util.ssl SslContextFactory)))
+  (:import (org.eclipse.jetty.util.ssl
+             SslContextFactory
+             SslContextFactory$Client)))
 
 (defn ^SslContextFactory insecure-ssl-context-factory
   []
-  (SslContextFactory. true))
+  (SslContextFactory$Client. true))

--- a/src/clj/qbits/jet/server.clj
+++ b/src/clj/qbits/jet/server.clj
@@ -33,7 +33,10 @@ Derived from ring.adapter.jetty"
    (org.eclipse.jetty.util.thread
     QueuedThreadPool
     ScheduledExecutorScheduler)
-    (org.eclipse.jetty.util.ssl KeyStoreScanner SslContextFactory)
+    (org.eclipse.jetty.util.ssl
+      KeyStoreScanner
+      SslContextFactory
+      SslContextFactory$Server)
    (org.eclipse.jetty.websocket.server WebSocketHandler)
    (org.eclipse.jetty.websocket.servlet
     WebSocketServletFactory
@@ -131,7 +134,7 @@ Derived from ring.adapter.jetty"
     :keys [client-auth http2?
            keystore keystore-type key-password
            truststore trust-password truststore-type]}]
-  (let [context (SslContextFactory.)]
+  (let [context (SslContextFactory$Server.)]
     (if (string? keystore)
       (.setKeyStorePath context keystore)
       (.setKeyStore context ^java.security.KeyStore keystore))


### PR DESCRIPTION
Using the `SslContextFactory.Server` class for loading server certs lets you load certificates for multiple domains in a single file without error.

As per the Jetty-9 docs:

> Use SslContextFactory.Server to configure server-side connectors, and SslContextFactory.Client to configure HTTP or WebSocket clients.

https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/util/ssl/SslContextFactory.html