### PR TITLE
Disable signature on Clojars deploywa

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  [org.eclipse.jetty.http2/http2-http-client-transport ~jetty-version]
                  [org.eclipse.jetty.http2/http2-client ~jetty-version]
                  [cheshire "5.5.0"]]
-
+  :deploy-repositories [["clojars" {:url "https://clojars.org/repo/" :sign-releases false}]]
   :plugins [[info.sunng/lein-bootclasspath-deps "0.3.0"]]
 
   :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"


### PR DESCRIPTION
Makes it much easier to push to clojars:
```
lein with-profiles +voom,+auth voom deploy clojars
```
We don't have a standard key that we use to sign these anyway.